### PR TITLE
Fix owner

### DIFF
--- a/src/Mpociot/Teamwork/Traits/UserHasTeams.php
+++ b/src/Mpociot/Teamwork/Traits/UserHasTeams.php
@@ -80,8 +80,9 @@ trait UserHasTeams
      */
     public function isOwner()
     {
-        return ( $this->teams()->where( "owner_id", "=", $this->getKey() )->first() ) ? true : false;
-    }
+	    $CurrentTeam=$this->currentTeam['id'];
+		return ( $this->teams()->where('id',$CurrentTeam)->where( "owner_id", "=", $this->getKey() )->first() ) ? true : false;
+	}
 
     /**
      * Wrapper method for "isOwner"


### PR DESCRIPTION
If another user has a team and is invited to another that was not created by him, the first value he finds with the user's id is being taken.