### PR TITLE
Fix PSR-4 Namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Mpociot\\Teamwork\\": "src/"
+            "Mpociot\\Teamwork\\": "src/Mpociot/Teamwork"
         },
         "files": [
             "src/helpers.php"


### PR DESCRIPTION
> Deprecation Notice: Class Mpociot\Teamwork\\[...] located in ./vendor/oliuz/teamwork/src/Mpociot/Teamwork/[...] does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.