### PR TITLE
Qualified column names in traits

### DIFF
--- a/src/Traits/TeamworkTeamTrait.php
+++ b/src/Traits/TeamworkTeamTrait.php
@@ -54,7 +54,7 @@ trait TeamworkTeamTrait
      */
     public function hasUser( Model $user )
     {
-        return $this->users()->where( $user->getKeyName(), "=", $user->getKey() )->first() ? true : false;
+        return $this->users()->where( $user->getQualifiedKeyName(), "=", $user->getKey() )->first() ? true : false;
     }
 
 }

--- a/src/Traits/UserHasTeams.php
+++ b/src/Traits/UserHasTeams.php
@@ -80,9 +80,13 @@ trait UserHasTeams
      */
     public function isOwner()
     {
-	    $CurrentTeam=$this->currentTeam['id'];
-		return ( $this->teams()->where('id',$CurrentTeam)->where( "owner_id", "=", $this->getKey() )->first() ) ? true : false;
-	}
+        $CurrentTeam = $this->currentTeam['id'];
+
+        $teamModelName   = Config::get('teamwork.team_model');
+        $teamModel = new $teamModelName();
+
+        return ( $this->teams()->where($teamModel->getQualifiedKeyName(), $CurrentTeam)->where( $teamModel->qualifyColumn('owner_id'), "=", $this->getKey() )->first() ) ? true : false;
+    }
 
     /**
      * Wrapper method for "isOwner"


### PR DESCRIPTION
In order to avoid "ambiguous column name" errors on joins.