### PR TITLE
Avoid problems with seeders and factories

### DIFF
--- a/src/Models/TeamworkTeam.php
+++ b/src/Models/TeamworkTeam.php
@@ -56,7 +56,7 @@ class TeamworkTeam extends Model
         static::creating(function ($model) {
             $model->uuid = (string)Uuid::uuid1();
             $model->slug = Str::slug($model->name);
-            $model->owner_id = auth()->user()->getKey();
+            $model->owner_id = $model->owner_id ?? auth()->user()->getKey();
         });
 
         static::updating(function ($model) {


### PR DESCRIPTION
It is not always a logged in user , that creates a team.
In seeders, tests and factories, I set the $model->owner_id manually and I get an error from this class.

This change prevents that.
```php
$model->owner_id = $model->owner_id ?? auth()->user()->getKey();
```